### PR TITLE
fix code block typo from getters.md

### DIFF
--- a/docs/core-concepts/getters.md
+++ b/docs/core-concepts/getters.md
@@ -168,7 +168,7 @@ store.count = 3
 store.doubleCount // 6
 </script>
 ```
-```
+
 
 ## 옵션 API에서 사용 %{#usage-with-the-options-api}%
 


### PR DESCRIPTION
[게터](https://pinia.vuejs.kr/core-concepts/getters.html#usage-with-setup)에서 마크다운 코드블록 오타가 보여서 수정했습니다!